### PR TITLE
Drop minSdk to 14

### DIFF
--- a/viewstatepageradapter/build.gradle
+++ b/viewstatepageradapter/build.gradle
@@ -6,7 +6,7 @@ android {
   buildToolsVersion "25.0.2"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 14
   }
 
   lintOptions {


### PR DESCRIPTION
Because the support libraries support 14 too and not just 15, and because there's no reason to exclude these few devices still in 14 that could run the apps properly.